### PR TITLE
Use ConduitM instead of Producer in type signatures. This simplifies …

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: conduit-throttle
-version: '0.2.1.0'
+version: '0.3.0.0'
 synopsis: Throttle Conduit Producers
 description: This packages is based on the throttle-io-stream package
              and provides functionality for throttling Conduit

--- a/src/Data/Conduit/Throttle.hs
+++ b/src/Data/Conduit/Throttle.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE RecordWildCards   #-}
 
 module Data.Conduit.Throttle
@@ -27,9 +26,9 @@ import           UnliftIO
 -- provided producer but throttled according to the provided
 -- throttling configuration.
 throttleProducer :: (MonadUnliftIO m, MonadResource m)
-                 => Conf a
-                 -> Producer m a
-                 -> Producer m a
+                 => Conf o
+                 -> ConduitM () o m ()
+                 -> ConduitM () o m ()
 throttleProducer conf producer = do
   (UnliftIO unlifter) <- lift askUnliftIO
   queueIn  <- liftIO $ newTBMQueueIO 1024

--- a/src/Data/Conduit/Throttle/MBC.hs
+++ b/src/Data/Conduit/Throttle/MBC.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes        #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RecordWildCards       #-}
 
 module Data.Conduit.Throttle.MBC
   ( Conf
@@ -16,24 +16,23 @@ module Data.Conduit.Throttle.MBC
   ) where
 
 import           Conduit
+import           Control.Concurrent.Async
 import           Control.Concurrent.STM
 import           Control.Concurrent.STM.TBMQueue
-import Control.Monad
 import qualified Control.Concurrent.Throttle     as Throttle
+import           Control.Monad
+import           Control.Monad.Trans.Control
 import           Control.Monad.Trans.Resource
 import           Data.Conduit.Throttle.Internal
-import Control.Concurrent.Async
-import Control.Monad.Trans.Control
 
 -- | Given a 'ThrottleConf' and a 'Producer', create and return a new
 -- 'Producer', which yields the same stream of values like the
 -- provided producer but throttled according to the provided
 -- throttling configuration.
-throttleProducer :: forall a m.
-                    (MonadIO m, MonadBaseControl IO m, MonadResource m)
-                 => Conf a
-                 -> Producer m a
-                 -> Producer m a
+throttleProducer :: (MonadIO m, MonadBaseControl IO m, MonadResource m)
+                 => Conf o
+                 -> ConduitM () o m ()
+                 -> ConduitM () o m ()
 throttleProducer conf producer = do
   queueIn  <- liftIO $ newTBMQueueIO 1024
   queueOut <- liftIO $ newTBMQueueIO 1
@@ -50,7 +49,7 @@ throttleProducer conf producer = do
   (_, asyncThrottler) <- allocate
     (Throttle.throttle throttleConf readCallback writeCallback)
     cancel
-                                            
+
   liftIO $ link asyncThrottler
   go queueOut
 

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -2,13 +2,7 @@
 
 module Main where
 
-import           Conduit
-import           Data.Conduit.Async
-import           Data.Conduit.List              (sourceList)
-import qualified Data.Conduit.Throttle          as ConduitThrottle
-import           Data.Function                  ((&))
-import           Test.Framework                 (Test, defaultMain, testGroup)
-import           Test.Framework.Providers.HUnit (testCase)
+import           Test.Framework                 (Test, defaultMain)
 
 import qualified Data.Conduit.Throttle.MBC.Test
 import qualified Data.Conduit.Throttle.Test


### PR DESCRIPTION
…type inference.