### PR TITLE
Update to nightly-2017-12-20

### DIFF
--- a/src/Data/Conduit/Throttle.hs
+++ b/src/Data/Conduit/Throttle.hs
@@ -14,7 +14,6 @@ module Data.Conduit.Throttle
   ) where
 
 import           Conduit
-import           Control.Concurrent.STM
 import           Control.Concurrent.STM.TBMQueue
 import qualified Control.Concurrent.Throttle     as Throttle
 import           Control.Monad.Trans.Resource

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.11
+resolver: nightly-2017-12-20
 packages:
 - '.'
 extra-deps: [throttle-io-stream-0.2.0.1]


### PR DESCRIPTION
Remove import of Control.Concurrent.STM since unliftio now contains 'atomically'